### PR TITLE
feat(dev): add dev Docker Compose with PostgreSQL, Valkey, and Tap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,143 @@
+# Barazo Environment Configuration
+#
+# Copy this file to .env (production) or .env.dev (development) and edit values.
+# Lines starting with # are comments. Uncomment to override defaults.
+#
+# SECURITY: Never commit .env files containing real secrets.
+
+# ==============================================================================
+# Community Identity
+# ==============================================================================
+
+# Display name for your forum community
+COMMUNITY_NAME="My Community"
+
+# Domain where your forum is hosted (used by Caddy for SSL)
+# COMMUNITY_DOMAIN="forum.example.com"
+
+# AT Protocol DID for your community (created during setup)
+# COMMUNITY_DID="did:plc:xxxx"
+
+# Deployment mode: "single" for one community, "global" for aggregator
+COMMUNITY_MODE="single"
+
+# ==============================================================================
+# Database (PostgreSQL 16 + pgvector)
+# ==============================================================================
+
+# PostgreSQL superuser credentials (used to create the database)
+POSTGRES_USER="barazo"
+POSTGRES_PASSWORD="CHANGE_ME"
+POSTGRES_DB="barazo"
+
+# Host port mapping (change if 5432 is already in use)
+# POSTGRES_PORT="5432"
+
+# Application database URL (used by barazo-api)
+# Uses the application role with INSERT/UPDATE/DELETE/SELECT privileges
+DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}"
+
+# Migration database URL (used only by migration scripts)
+# Uses a migration role with DDL privileges
+# MIGRATION_DATABASE_URL="postgresql://barazo_migrator:CHANGE_ME@postgres:5432/${POSTGRES_DB}"
+
+# ==============================================================================
+# Cache (Valkey -- Redis-compatible)
+# ==============================================================================
+
+# Valkey password (optional in dev, required in production)
+# VALKEY_PASSWORD="CHANGE_ME"
+
+# Host port mapping (change if 6379 is already in use)
+# VALKEY_PORT="6379"
+
+# Cache URL (used by barazo-api)
+VALKEY_URL="redis://valkey:6379"
+
+# ==============================================================================
+# AT Protocol (Firehose via Tap)
+# ==============================================================================
+
+# Relay URL for the AT Protocol firehose
+TAP_RELAY_URL="https://bsky.network"
+
+# Host port mapping for Tap admin API (change if 2480 is already in use)
+# TAP_PORT="2480"
+
+# Tap admin password (for dev/debug access to Tap admin API)
+TAP_ADMIN_PASSWORD="tap_dev_secret"
+
+# ==============================================================================
+# AT Protocol (OAuth)
+# ==============================================================================
+
+# OAuth client ID (your forum's public URL)
+# OAUTH_CLIENT_ID="https://forum.example.com"
+
+# OAuth callback URL
+# OAUTH_REDIRECT_URI="https://forum.example.com/api/auth/callback"
+
+# ==============================================================================
+# Frontend (Next.js)
+# ==============================================================================
+
+# Public API URL (as seen by the browser)
+# NEXT_PUBLIC_API_URL="https://forum.example.com/api"
+
+# Public site URL
+# NEXT_PUBLIC_SITE_URL="https://forum.example.com"
+
+# ==============================================================================
+# Search (Optional Semantic Search)
+# ==============================================================================
+
+# When set, enables hybrid semantic search alongside full-text search.
+# Example: "http://ollama:11434/api/embeddings" for local Ollama
+# EMBEDDING_URL=""
+
+# Embedding vector dimensions (must match your model; default matches nomic-embed-text)
+# AI_EMBEDDING_DIMENSIONS="768"
+
+# ==============================================================================
+# Encryption
+# ==============================================================================
+
+# AES-256-GCM master key for encrypting BYOK API keys at rest.
+# Required if users will store their own AI provider keys.
+# Generate with: openssl rand -base64 32
+# AI_ENCRYPTION_KEY=""
+
+# ==============================================================================
+# Cross-Posting
+# ==============================================================================
+
+# Enable Frontpage cross-posting (Bluesky cross-posting is always available)
+# FEATURE_CROSSPOST_FRONTPAGE="false"
+
+# ==============================================================================
+# Plugins
+# ==============================================================================
+
+# Set to "false" to disable all plugins
+# PLUGINS_ENABLED="true"
+
+# npm registry URL for plugin installation (default: public npm registry)
+# PLUGIN_REGISTRY_URL="https://registry.npmjs.org"
+
+# ==============================================================================
+# Monitoring
+# ==============================================================================
+
+# GlitchTip/Sentry DSN for error reporting (optional)
+# GLITCHTIP_DSN=""
+
+# Log level: trace, debug, info, warn, error, fatal
+LOG_LEVEL="info"
+
+# ==============================================================================
+# Backups (Production only)
+# ==============================================================================
+
+# Public key for encrypting backups with age (recommended over GPG)
+# Generate a keypair with: age-keygen -o key.txt
+# BACKUP_PUBLIC_KEY=""

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,58 @@
+# Barazo Development Docker Compose
+#
+# Infrastructure services for local development of barazo-api and barazo-web.
+# Does NOT include the API or web containers (run those with pnpm dev:api / dev:web).
+#
+# Usage:
+#   cp .env.example .env.dev
+#   docker compose -f docker-compose.dev.yml up -d
+#
+# Services: PostgreSQL 16 (pgvector), Valkey 8, Tap (AT Protocol firehose)
+
+services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-barazo}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-barazo_dev}
+      POSTGRES_DB: ${POSTGRES_DB:-barazo}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-barazo}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  valkey:
+    image: valkey/valkey:8-alpine
+    ports:
+      - "${VALKEY_PORT:-6379}:6379"
+    volumes:
+      - valkeydata:/data
+    healthcheck:
+      test: ["CMD", "valkey-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  tap:
+    image: ghcr.io/bluesky-social/indigo/tap:latest
+    platform: linux/amd64
+    ports:
+      - "${TAP_PORT:-2480}:2480"
+    environment:
+      TAP_RELAY_URL: ${TAP_RELAY_URL:-https://bsky.network}
+      TAP_SIGNAL_COLLECTION: forum.barazo.topic.post
+      TAP_COLLECTION_FILTERS: forum.barazo.topic.post,forum.barazo.topic.reply,forum.barazo.interaction.reaction
+      TAP_DATABASE_URL: sqlite:///data/tap.db
+      TAP_ADMIN_PASSWORD: ${TAP_ADMIN_PASSWORD:-tap_dev_secret}
+    volumes:
+      - tapdata:/data
+
+volumes:
+  pgdata:
+  valkeydata:
+  tapdata:


### PR DESCRIPTION
## Summary

- Adds `docker-compose.dev.yml` with PostgreSQL 16 (pgvector), Valkey 8, and Tap (AT Protocol firehose consumer)
- Creates `.env.example` with all environment variables documented (grouped by service, with defaults and descriptions)
- Rewrites `README.md` with dev quick start guide, service table, common commands, environment variable reference, and troubleshooting section

Formalizes the dev infrastructure that was previously at the workspace root into the deploy repo. All port mappings are configurable via environment variables to avoid conflicts.

## Test plan

- [x] `docker compose -f docker-compose.dev.yml config` validates without errors
- [ ] `docker compose -f docker-compose.dev.yml up -d` starts all three services
- [ ] All services report healthy status via `docker compose ps`
- [ ] Workspace root `pnpm dev:infra` still works (path updated to `barazo-deploy/docker-compose.dev.yml`)