### PR TITLE
docs: fix broken troubleshooting link

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -118,4 +118,4 @@ The first user to complete the setup wizard becomes the community administrator.
 - Verify `DATABASE_URL` password matches `POSTGRES_PASSWORD`
 - Check PostgreSQL logs: `docker compose logs postgres`
 
-See also: [Troubleshooting](https://github.com/barazo-forum/barazo-deploy#troubleshooting) in README.
+See also: [Troubleshooting](administration.md#troubleshooting) in the Administration Guide.


### PR DESCRIPTION
## Summary

- Fix broken anchor link in `docs/installation.md` line 121
- The old link pointed to `https://github.com/barazo-forum/barazo-deploy#troubleshooting` which does not exist (README.md has no Troubleshooting heading)
- Changed to a relative link `administration.md#troubleshooting` which points to the Administration Guide that does have a Troubleshooting section

## Test plan

- [ ] Verify the link renders correctly on GitHub and navigates to the correct section in the Administration Guide