### PR TITLE
docs: add production deployment checklist and security hardening guide

### DIFF
--- a/docs/deployment-checklist.md
+++ b/docs/deployment-checklist.md
@@ -1,0 +1,244 @@
+# Production Deployment Checklist
+
+Step-by-step checklist for deploying Barazo to production on a Hetzner VPS.
+
+This checklist covers the first production deployment of `barazo.forum`. For self-hosted installations, see [Installation Guide](installation.md).
+
+## Pre-Deployment
+
+### Server Provisioning
+
+- [ ] Provision Hetzner CX32 VPS (4 vCPU, 8 GB RAM, 80 GB SSD)
+  - Location: Falkenstein or Helsinki (EU)
+  - OS: Ubuntu 24.04 LTS
+- [ ] Note the server's IPv4 and IPv6 addresses
+- [ ] SSH into the server and verify access: `ssh root@<IP>`
+
+### DNS Configuration
+
+- [ ] Create A record: `barazo.forum` -> server IPv4
+- [ ] Create AAAA record: `barazo.forum` -> server IPv6
+- [ ] Verify DNS propagation: `dig +short barazo.forum`
+- [ ] Verify reverse DNS (optional but recommended for email deliverability): set PTR record in Hetzner Cloud console
+
+### Server Setup
+
+- [ ] Update system packages:
+  ```bash
+  apt update && apt upgrade -y
+  ```
+- [ ] Create non-root deploy user:
+  ```bash
+  adduser barazo
+  usermod -aG sudo barazo
+  ```
+- [ ] Copy SSH key for deploy user:
+  ```bash
+  su - barazo
+  mkdir -p ~/.ssh
+  # Add your public key to ~/.ssh/authorized_keys
+  chmod 700 ~/.ssh && chmod 600 ~/.ssh/authorized_keys
+  ```
+- [ ] Disable root SSH login (see [Security Hardening Guide](security-hardening.md))
+- [ ] Install Docker:
+  ```bash
+  curl -fsSL https://get.docker.com | sh
+  sudo usermod -aG docker barazo
+  # Log out and back in
+  ```
+- [ ] Verify Docker:
+  ```bash
+  docker --version        # v24+
+  docker compose version  # v2+
+  ```
+
+## Deployment
+
+### Application Setup
+
+- [ ] Clone deploy repo:
+  ```bash
+  git clone https://github.com/barazo-forum/barazo-deploy.git
+  cd barazo-deploy
+  ```
+- [ ] Create `.env` from template:
+  ```bash
+  cp .env.example .env
+  ```
+- [ ] Generate secrets (run each one and paste into `.env`):
+  ```bash
+  # POSTGRES_PASSWORD
+  openssl rand -base64 24
+  # VALKEY_PASSWORD
+  openssl rand -base64 24
+  # TAP_ADMIN_PASSWORD
+  openssl rand -base64 24
+  # SESSION_SECRET
+  openssl rand -base64 32
+  # AI_ENCRYPTION_KEY (required for BYOK features)
+  openssl rand -base64 32
+  ```
+- [ ] Configure `.env` with production values:
+
+  | Variable | Value |
+  |----------|-------|
+  | `COMMUNITY_NAME` | `Barazo` |
+  | `COMMUNITY_DOMAIN` | `barazo.forum` |
+  | `COMMUNITY_MODE` | `global` |
+  | `POSTGRES_PASSWORD` | (generated above) |
+  | `VALKEY_PASSWORD` | (generated above) |
+  | `DATABASE_URL` | `postgresql://barazo_app:<POSTGRES_PASSWORD>@postgres:5432/barazo` |
+  | `MIGRATION_DATABASE_URL` | `postgresql://barazo_migrator:<POSTGRES_PASSWORD>@postgres:5432/barazo` |
+  | `TAP_ADMIN_PASSWORD` | (generated above) |
+  | `SESSION_SECRET` | (generated above) |
+  | `OAUTH_CLIENT_ID` | `https://barazo.forum` |
+  | `OAUTH_REDIRECT_URI` | `https://barazo.forum/api/auth/callback` |
+  | `NEXT_PUBLIC_API_URL` | `https://barazo.forum/api` |
+  | `NEXT_PUBLIC_SITE_URL` | `https://barazo.forum` |
+  | `GLITCHTIP_DSN` | (production GlitchTip DSN) |
+  | `AI_ENCRYPTION_KEY` | (generated above) |
+
+- [ ] Pin Docker image versions in `docker-compose.yml`:
+  ```yaml
+  barazo-api:
+    image: ghcr.io/barazo-forum/barazo-api:X.Y.Z
+  barazo-web:
+    image: ghcr.io/barazo-forum/barazo-web:X.Y.Z
+  ```
+- [ ] Verify no `CHANGE_ME` values remain:
+  ```bash
+  grep -n "CHANGE_ME" .env
+  ```
+
+### Start Services
+
+- [ ] Pull images:
+  ```bash
+  docker compose pull
+  ```
+- [ ] Start the stack:
+  ```bash
+  docker compose up -d
+  ```
+- [ ] Watch startup logs:
+  ```bash
+  docker compose logs -f
+  ```
+
+## Post-Deployment Verification
+
+### Health Checks
+
+- [ ] All containers healthy:
+  ```bash
+  docker compose ps
+  # All services should show "healthy"
+  ```
+- [ ] API health check:
+  ```bash
+  curl -s https://barazo.forum/api/health | jq .
+  ```
+- [ ] Run smoke test:
+  ```bash
+  ./scripts/smoke-test.sh https://barazo.forum
+  ```
+
+### SSL Verification
+
+- [ ] HTTPS works: visit `https://barazo.forum` in browser
+- [ ] HTTP redirects to HTTPS: `curl -I http://barazo.forum`
+- [ ] Certificate is valid:
+  ```bash
+  echo | openssl s_client -connect barazo.forum:443 -servername barazo.forum 2>/dev/null | openssl x509 -noout -dates
+  ```
+- [ ] HSTS header present:
+  ```bash
+  curl -sI https://barazo.forum | grep -i strict-transport
+  ```
+
+### Functional Verification
+
+- [ ] Homepage renders in browser
+- [ ] OAuth login redirects to Bluesky correctly
+- [ ] API documentation accessible at `https://barazo.forum/docs`
+- [ ] `/api/health/ready` blocked externally (returns 403):
+  ```bash
+  curl -s -o /dev/null -w "%{http_code}" https://barazo.forum/api/health/ready
+  ```
+
+### Backup Setup
+
+- [ ] Generate backup encryption keypair:
+  ```bash
+  sudo apt install age
+  age-keygen -o barazo-backup-key.txt
+  # Add public key to .env as BACKUP_PUBLIC_KEY
+  # Store private key OFF-SERVER (e.g., password manager)
+  ```
+- [ ] Test backup:
+  ```bash
+  ./scripts/backup.sh --encrypt
+  ls -lh backups/
+  ```
+- [ ] Set up automated daily backups:
+  ```bash
+  crontab -e
+  ```
+  ```
+  0 2 * * * cd /home/barazo/barazo-deploy && ./scripts/backup.sh --encrypt >> /var/log/barazo-backup.log 2>&1
+  ```
+- [ ] Verify backup cron runs (check next day):
+  ```bash
+  ls -lh backups/
+  tail /var/log/barazo-backup.log
+  ```
+
+### Monitoring
+
+- [ ] GlitchTip DSN configured and receiving events
+- [ ] Test error reporting:
+  ```bash
+  # Trigger a test error via the API (if endpoint exists)
+  # Or check GlitchTip dashboard for startup events
+  ```
+- [ ] Log output visible:
+  ```bash
+  docker compose logs --tail=20 barazo-api
+  ```
+
+### Security Hardening
+
+- [ ] Complete the [Security Hardening Guide](security-hardening.md) checklist
+- [ ] Firewall configured (only 22, 80, 443 open)
+- [ ] SSH root login disabled
+- [ ] Unattended upgrades enabled
+
+## Ongoing Operations
+
+### Upgrades
+
+See [Upgrade Guide](upgrading.md) for the standard upgrade process:
+
+```bash
+# Update image tags in docker-compose.yml, then:
+docker compose pull
+docker compose up -d
+```
+
+### Rollback
+
+If an upgrade causes issues:
+
+```bash
+# Revert image tags in docker-compose.yml to previous versions, then:
+docker compose pull
+docker compose up -d
+```
+
+Database migrations run automatically on API startup. If a migration introduced a breaking change, restore from backup (see [Backup & Restore](backups.md)).
+
+### Daily Checks
+
+- [ ] `docker compose ps` -- all services healthy
+- [ ] Check GlitchTip for new errors
+- [ ] Verify backup ran (check `/var/log/barazo-backup.log`)

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -1,0 +1,295 @@
+# Security Hardening Guide
+
+Security configuration for a production Barazo deployment on a Linux VPS.
+
+The Docker Compose templates ship with secure defaults (non-root containers, two-network segmentation, no unnecessary exposed ports). This guide covers the server-level hardening that complements those defaults.
+
+## SSH Configuration
+
+### Disable Root Login and Password Authentication
+
+Edit `/etc/ssh/sshd_config`:
+
+```
+PermitRootLogin no
+PasswordAuthentication no
+PubkeyAuthentication yes
+MaxAuthTries 3
+ClientAliveInterval 300
+ClientAliveCountMax 2
+```
+
+Restart SSH:
+
+```bash
+sudo systemctl restart sshd
+```
+
+**Before disabling root login**, verify you can SSH in as your deploy user (`barazo`) with key-based auth.
+
+### Change Default SSH Port (Optional)
+
+Reduces automated scan noise. Not a security measure on its own.
+
+```
+Port 2222
+```
+
+If you change the SSH port, update your firewall rules accordingly.
+
+## Firewall (UFW)
+
+```bash
+# Install
+sudo apt install ufw
+
+# Default policy: deny all incoming, allow outgoing
+sudo ufw default deny incoming
+sudo ufw default allow outgoing
+
+# Allow SSH (use your port if changed)
+sudo ufw allow 22/tcp comment 'SSH'
+
+# Allow HTTP and HTTPS (required for Caddy)
+sudo ufw allow 80/tcp comment 'HTTP'
+sudo ufw allow 443/tcp comment 'HTTPS'
+sudo ufw allow 443/udp comment 'HTTP/3 QUIC'
+
+# Enable firewall
+sudo ufw enable
+
+# Verify
+sudo ufw status verbose
+```
+
+**Expected output:** only ports 22, 80, 443 (TCP), and 443 (UDP) open.
+
+### Docker and UFW
+
+Docker manipulates iptables directly, which can bypass UFW rules. To prevent Docker from exposing ports that UFW blocks, create `/etc/docker/daemon.json`:
+
+```json
+{
+  "iptables": false
+}
+```
+
+Then restart Docker:
+
+```bash
+sudo systemctl restart docker
+```
+
+**Note:** With `iptables: false`, you must ensure the host firewall allows traffic to Docker's published ports (80, 443). The UFW rules above handle this. Test after applying to confirm services remain accessible.
+
+## Automatic Security Updates
+
+```bash
+sudo apt install unattended-upgrades
+sudo dpkg-reconfigure -plow unattended-upgrades
+```
+
+This enables automatic installation of security patches. Kernel updates may require a reboot -- consider enabling automatic reboots during a maintenance window:
+
+Edit `/etc/apt/apt.conf.d/50unattended-upgrades`:
+
+```
+Unattended-Upgrade::Automatic-Reboot "true";
+Unattended-Upgrade::Automatic-Reboot-Time "04:00";
+```
+
+## Docker Security
+
+### Container Defaults (Already Configured)
+
+The `docker-compose.yml` ships with these security measures:
+
+- **Non-root containers:** All Barazo images run as non-root users
+- **No privileged mode:** No containers use `--privileged` or `cap_add`
+- **Restart policy:** `unless-stopped` on all services (recovers from crashes, stops on manual `docker compose down`)
+- **Health checks:** All services have Docker health checks with appropriate intervals and retries
+
+### Resource Limits
+
+Uncomment the resource limits in `docker-compose.yml` to prevent any single service from consuming all server resources:
+
+```yaml
+# Recommended limits for CX32 (4 vCPU, 8 GB RAM)
+services:
+  postgres:
+    mem_limit: 2g
+    cpus: 1.5
+  valkey:
+    mem_limit: 512m
+    cpus: 0.5
+  tap:
+    mem_limit: 512m
+    cpus: 0.5
+  barazo-api:
+    mem_limit: 2g
+    cpus: 1.5
+  barazo-web:
+    mem_limit: 1g
+    cpus: 0.5
+  caddy:
+    mem_limit: 256m
+    cpus: 0.25
+```
+
+### Read-Only Filesystems (Optional)
+
+For additional isolation, enable read-only root filesystems on containers that don't need write access beyond their volumes:
+
+```yaml
+services:
+  valkey:
+    read_only: true
+    tmpfs:
+      - /tmp
+  caddy:
+    read_only: true
+    tmpfs:
+      - /tmp
+```
+
+### Docker Socket Protection
+
+Never mount the Docker socket (`/var/run/docker.sock`) into any container. None of the Barazo services require it.
+
+### Image Updates
+
+Keep base images updated. Dependabot is configured in the repo for automated image update PRs. On the server:
+
+```bash
+# Pull latest pinned versions
+docker compose pull
+
+# Prune old images
+docker image prune -f
+```
+
+## Network Segmentation
+
+The Compose file uses two-network segmentation:
+
+```
+Internet -> [80/443] -> Caddy (frontend network)
+                          |
+                     barazo-web (frontend network)
+                          |
+                     barazo-api (frontend + backend networks)
+                          |
+                 PostgreSQL, Valkey, Tap (backend network only)
+```
+
+- **PostgreSQL and Valkey are not reachable from the internet** -- they are on the `backend` network only
+- **Only Caddy exposes ports** (80, 443) -- no other service is directly accessible
+- **barazo-api bridges both networks** -- it receives HTTP requests via Caddy and connects to the database
+
+Do not add `ports:` to any service other than Caddy.
+
+## Caddy Security
+
+### Headers (Already Configured)
+
+Caddy automatically enables:
+
+- **HSTS** (Strict-Transport-Security) -- enforced by default
+- **HTTP to HTTPS redirect** -- automatic
+
+### Admin API
+
+The Caddy admin API is disabled in the Caddyfile (`admin off`). This prevents runtime configuration changes via HTTP.
+
+### Internal Endpoints
+
+The `/api/health/ready` endpoint is blocked at the Caddy level (returns 403). This endpoint exposes readiness state and should only be accessed from within the Docker network for orchestration purposes.
+
+## Database Security
+
+### Role Separation
+
+Barazo uses three PostgreSQL roles with least-privilege access:
+
+| Role | Privileges | Used By |
+|------|-----------|---------|
+| `barazo_migrator` | DDL (CREATE, ALTER, DROP) | Migration scripts only |
+| `barazo_app` | DML (SELECT, INSERT, UPDATE, DELETE) | API server |
+| `barazo_readonly` | SELECT only | Search, public endpoints, reporting |
+
+The API server connects with `barazo_app` -- it cannot modify the schema. Migrations use `barazo_migrator` and run only during startup.
+
+### Connection Security
+
+PostgreSQL is on the backend network only. It is not exposed to the host or the internet. The `DATABASE_URL` uses Docker's internal DNS (`postgres:5432`).
+
+Do not add `ports:` to the PostgreSQL service in `docker-compose.yml`.
+
+### Password Strength
+
+Generate all database passwords with:
+
+```bash
+openssl rand -base64 24
+```
+
+This produces a 32-character password with high entropy.
+
+## Valkey (Redis) Security
+
+### Authentication
+
+Valkey requires a password (`--requirepass`). The password is set via `VALKEY_PASSWORD` in `.env`.
+
+### Dangerous Commands Disabled
+
+The following commands are renamed to empty strings (effectively disabled):
+
+- `FLUSHALL` -- prevents accidental cache wipe
+- `FLUSHDB` -- prevents accidental database wipe
+- `CONFIG` -- prevents runtime configuration changes
+- `DEBUG` -- prevents debug information leaks
+- `KEYS` -- prevents expensive keyspace scans in production
+
+### Network Isolation
+
+Like PostgreSQL, Valkey is on the backend network only and not exposed to the host.
+
+## Secrets Management
+
+### Environment Variables
+
+- All secrets are in `.env` (never in `docker-compose.yml` or committed to git)
+- `.env` is in `.gitignore`
+- `.env.example` uses `CHANGE_ME` placeholders
+
+### File Permissions
+
+```bash
+# Restrict .env to owner only
+chmod 600 .env
+
+# Restrict backup encryption key
+chmod 600 barazo-backup-key.txt
+```
+
+### Backup Encryption
+
+Backups must be encrypted before off-server storage. See [Backup & Restore](backups.md) for setup with `age`.
+
+## Checklist
+
+Use this as a post-deployment verification:
+
+- [ ] SSH: root login disabled, password auth disabled
+- [ ] Firewall: only 22, 80, 443 (TCP), 443 (UDP) open
+- [ ] Unattended upgrades enabled
+- [ ] Resource limits set in `docker-compose.yml`
+- [ ] No `CHANGE_ME` in `.env`: `grep CHANGE_ME .env` returns nothing
+- [ ] `.env` file permissions: `ls -la .env` shows `-rw-------`
+- [ ] PostgreSQL not exposed: `curl localhost:5432` connection refused
+- [ ] Valkey not exposed: `curl localhost:6379` connection refused
+- [ ] `/api/health/ready` returns 403 externally
+- [ ] Caddy admin API disabled: confirmed `admin off` in Caddyfile
+- [ ] Backup encryption configured and tested
+- [ ] Docker images pinned to specific versions (not `:latest`)


### PR DESCRIPTION
## Summary

- Add production deployment checklist (`docs/deployment-checklist.md`) with step-by-step guide for deploying barazo.forum on Hetzner VPS
- Add security hardening guide (`docs/security-hardening.md`) covering SSH, firewall, Docker security, network segmentation, and database access
- Completes Deploy M5 (Production Readiness) gaps

## Changes

- `docs/deployment-checklist.md` -- Pre-deployment (server provisioning, DNS, server setup), deployment (env config, secrets generation, service startup), post-deployment verification (health checks, SSL, functional tests, backup setup, monitoring)
- `docs/security-hardening.md` -- SSH hardening, UFW firewall with Docker iptables fix, automatic security updates, Docker container security (resource limits, read-only fs), network segmentation explanation, database role separation, Valkey command restrictions, secrets management

## Test plan

- [ ] CI passes
- [ ] Review checklist steps against `prd-deploy.md` Section 12 (Security Defaults) and Section 8 (Server Requirements)
- [ ] Verify all referenced scripts and docs exist in the repo