### PR TITLE
Add HSTS header to Caddyfile

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -13,6 +13,9 @@
 }
 
 {$COMMUNITY_DOMAIN} {
+	# HSTS -- enforce HTTPS for all future requests (2 years, preload-eligible)
+	header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
+
 	# Block /api/health/ready from external access (internal monitoring only)
 	@healthReady path /api/health/ready
 	handle @healthReady {


### PR DESCRIPTION
## Summary
- Adds `Strict-Transport-Security` header (`max-age=63072000; includeSubDomains; preload`) to the Caddy reverse proxy config
- Ensures all Barazo domains enforce HTTPS after first visit, meeting the HSTS preload requirements
- Already deployed and verified on staging (`staging.barazo.forum`)

## Test plan
- [x] Deployed updated Caddyfile to staging server
- [x] Restarted Caddy container
- [x] Verified header present: `curl -sI https://staging.barazo.forum | grep -i strict`