### PR TITLE
fix(config): replace NEXT_PUBLIC_API_URL with API_INTERNAL_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,8 +81,9 @@ TAP_ADMIN_PASSWORD="tap_dev_secret"
 # Frontend (Next.js)
 # ==============================================================================
 
-# Public API URL (as seen by the browser)
-# NEXT_PUBLIC_API_URL="https://forum.example.com/api"
+# Internal API URL for server-side rendering (Docker service name)
+# Only needed if the default (http://localhost:3000) doesn't work in your setup
+# API_INTERNAL_URL="http://barazo-api:3000"
 
 # Public site URL
 # NEXT_PUBLIC_SITE_URL="https://forum.example.com"

--- a/.env.staging
+++ b/.env.staging
@@ -45,7 +45,7 @@ OAUTH_REDIRECT_URI="https://staging.barazo.forum/api/auth/callback"
 # Frontend
 # ==============================================================================
 
-NEXT_PUBLIC_API_URL="https://staging.barazo.forum/api"
+API_INTERNAL_URL="http://barazo-api:3000"
 NEXT_PUBLIC_SITE_URL="https://staging.barazo.forum"
 
 # ==============================================================================

--- a/.github/workflows/build-smoke-test.yml
+++ b/.github/workflows/build-smoke-test.yml
@@ -31,7 +31,6 @@ jobs:
       COMMUNITY_MODE: single
       OAUTH_CLIENT_ID: http://localhost
       OAUTH_REDIRECT_URI: http://localhost/api/auth/callback
-      NEXT_PUBLIC_API_URL: http://localhost/api
       NEXT_PUBLIC_SITE_URL: http://localhost
       BARAZO_API_VERSION: latest
       BARAZO_WEB_VERSION: latest

--- a/.github/workflows/validate-compose.yml
+++ b/.github/workflows/validate-compose.yml
@@ -32,7 +32,6 @@ jobs:
           COMMUNITY_DOMAIN: ci.example.com
           OAUTH_CLIENT_ID: https://ci.example.com
           OAUTH_REDIRECT_URI: https://ci.example.com/api/auth/callback
-          NEXT_PUBLIC_API_URL: https://ci.example.com/api
           NEXT_PUBLIC_SITE_URL: https://ci.example.com
         run: docker compose -f docker-compose.yml config --quiet
 
@@ -49,7 +48,6 @@ jobs:
           COMMUNITY_DOMAIN: ci.example.com
           OAUTH_CLIENT_ID: https://ci.example.com
           OAUTH_REDIRECT_URI: https://ci.example.com/api/auth/callback
-          NEXT_PUBLIC_API_URL: https://ci.example.com/api
           NEXT_PUBLIC_SITE_URL: https://ci.example.com
         run: docker compose -f docker-compose.yml -f docker-compose.global.yml config --quiet
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ All variables are documented in [`.env.example`](.env.example). Key groups:
 | Cache | `VALKEY_PASSWORD`, `VALKEY_URL` | Password required in production |
 | AT Protocol | `TAP_RELAY_URL`, `TAP_ADMIN_PASSWORD`, `RELAY_URL` | Default relay: `bsky.network` |
 | OAuth | `OAUTH_CLIENT_ID`, `OAUTH_REDIRECT_URI` | Set to your forum's public URL |
-| Frontend | `NEXT_PUBLIC_API_URL`, `NEXT_PUBLIC_SITE_URL` | As seen by the browser |
+| Frontend | `API_INTERNAL_URL`, `NEXT_PUBLIC_SITE_URL` | `API_INTERNAL_URL` for SSR (default: `http://localhost:3000`); browser uses relative URLs |
 | Search | `EMBEDDING_URL`, `AI_EMBEDDING_DIMENSIONS` | Optional semantic search via Ollama or compatible API |
 | Encryption | `AI_ENCRYPTION_KEY` | AES-256-GCM key for BYOK API key encryption at rest |
 | Cross-Posting | `FEATURE_CROSSPOST_FRONTPAGE` | Frontpage cross-posting toggle |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,7 +137,7 @@ services:
     restart: unless-stopped
     environment:
       NODE_ENV: production
-      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}
+      API_INTERNAL_URL: http://barazo-api:3000
       NEXT_PUBLIC_SITE_URL: ${NEXT_PUBLIC_SITE_URL}
     networks:
       - frontend

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,7 +44,7 @@ All Barazo environment variables with descriptions, defaults, and examples.
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `NEXT_PUBLIC_API_URL` | Yes | -- | Public API URL as seen by browsers (e.g., `https://forum.example.com/api`) |
+| `API_INTERNAL_URL` | No | `http://localhost:3000` | Internal API URL for server-side rendering. Set to `http://barazo-api:3000` in Docker. |
 | `NEXT_PUBLIC_SITE_URL` | Yes | -- | Public site URL (e.g., `https://forum.example.com`) |
 
 ## Image Versions

--- a/docs/deployment-checklist.md
+++ b/docs/deployment-checklist.md
@@ -93,7 +93,6 @@ This checklist covers the first production deployment of `barazo.forum`. For sel
   | `SESSION_SECRET` | (generated above) |
   | `OAUTH_CLIENT_ID` | `https://barazo.forum` |
   | `OAUTH_REDIRECT_URI` | `https://barazo.forum/api/auth/callback` |
-  | `NEXT_PUBLIC_API_URL` | `https://barazo.forum/api` |
   | `NEXT_PUBLIC_SITE_URL` | `https://barazo.forum` |
   | `GLITCHTIP_DSN` | (production GlitchTip DSN) |
   | `AI_ENCRYPTION_KEY` | (generated above) |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -57,7 +57,6 @@ nano .env  # or your preferred editor
 | `DATABASE_URL` | Update the password to match `POSTGRES_PASSWORD` |
 | `OAUTH_CLIENT_ID` | `https://your-domain.com` |
 | `OAUTH_REDIRECT_URI` | `https://your-domain.com/api/auth/callback` |
-| `NEXT_PUBLIC_API_URL` | `https://your-domain.com/api` |
 | `NEXT_PUBLIC_SITE_URL` | `https://your-domain.com` |
 
 Generate passwords with:


### PR DESCRIPTION
## Summary

- Replaces `NEXT_PUBLIC_API_URL` with `API_INTERNAL_URL: http://barazo-api:3000` in `docker-compose.yml`
- Updates `.env.example`, `.env.staging`, CI workflows, docs, and README
- Removes all references to `NEXT_PUBLIC_API_URL` across the repo

## Context

Companion to barazo-forum/barazo-web PR. The frontend now uses relative URLs for browser-side fetch (Caddy proxies `/api/*`), so `NEXT_PUBLIC_API_URL` is no longer needed. `API_INTERNAL_URL` is a non-public env var used only for server-side rendering inside Docker.

## Test plan

- [ ] `docker compose config --quiet` passes with updated env
- [ ] CI workflows validate successfully
- [ ] Deploy to staging and verify OAuth + API calls work end-to-end