### PR TITLE
fix(staging): use :edge tag instead of :latest

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -102,7 +102,7 @@ jobs:
           file: barazo-api/Dockerfile
           push: true
           tags: |
-            ${{ env.REGISTRY }}/barazo-forum/barazo-api:latest
+            ${{ env.REGISTRY }}/barazo-forum/barazo-api:edge
             ${{ env.REGISTRY }}/barazo-forum/barazo-api:staging-${{ github.run_number }}
           cache-from: type=gha,scope=api
           cache-to: type=gha,mode=max,scope=api
@@ -115,7 +115,7 @@ jobs:
           file: barazo-web/Dockerfile
           push: true
           tags: |
-            ${{ env.REGISTRY }}/barazo-forum/barazo-web:latest
+            ${{ env.REGISTRY }}/barazo-forum/barazo-web:edge
             ${{ env.REGISTRY }}/barazo-forum/barazo-web:staging-${{ github.run_number }}
           cache-from: type=gha,scope=web
           cache-to: type=gha,mode=max,scope=web
@@ -272,13 +272,13 @@ jobs:
             if [ -n "$API_DIGEST" ] && [ "$API_DIGEST" != "no-previous-api" ]; then
               echo "Rolling back API to: $API_DIGEST"
               docker pull "$API_DIGEST"
-              docker tag "$API_DIGEST" ghcr.io/barazo-forum/barazo-api:latest
+              docker tag "$API_DIGEST" ghcr.io/barazo-forum/barazo-api:edge
             fi
 
             if [ -n "$WEB_DIGEST" ] && [ "$WEB_DIGEST" != "no-previous-web" ]; then
               echo "Rolling back Web to: $WEB_DIGEST"
               docker pull "$WEB_DIGEST"
-              docker tag "$WEB_DIGEST" ghcr.io/barazo-forum/barazo-web:latest
+              docker tag "$WEB_DIGEST" ghcr.io/barazo-forum/barazo-web:edge
             fi
 
             docker compose ${{ env.COMPOSE_FILES }} up -d

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,7 +1,7 @@
 # Barazo Staging Docker Compose -- Override
 #
 # Extends docker-compose.yml for the staging environment (staging.barazo.forum).
-# Uses :latest images, debug logging, and relaxed rate limits for testing.
+# Uses :edge images, debug logging, and relaxed rate limits for testing.
 #
 # Usage:
 #   cp .env.staging .env
@@ -17,7 +17,7 @@
 services:
   # Override API for staging
   barazo-api:
-    image: ghcr.io/barazo-forum/barazo-api:latest
+    image: ghcr.io/barazo-forum/barazo-api:edge
     environment:
       NODE_ENV: staging
       LOG_LEVEL: debug
@@ -27,7 +27,7 @@ services:
 
   # Override Web for staging
   barazo-web:
-    image: ghcr.io/barazo-forum/barazo-web:latest
+    image: ghcr.io/barazo-forum/barazo-web:edge
 
   # Staging postgres -- no resource overrides, keep defaults
   # (staging uses smallest Hetzner VPS)

--- a/infrastructure/staging.md
+++ b/infrastructure/staging.md
@@ -120,7 +120,7 @@ docker compose -f docker-compose.yml -f docker-compose.staging.yml up -d
 ```
 
 The staging override (`docker-compose.staging.yml`) sets:
-- `:latest` image tags
+- `:edge` image tags (`:latest` is reserved for stable releases)
 - `NODE_ENV: staging`
 - `LOG_LEVEL: debug`
 - Relaxed rate limits for testing
@@ -128,5 +128,7 @@ The staging override (`docker-compose.staging.yml`) sets:
 ## Image Tags
 
 Each deploy produces two tags per image:
-- `:latest` -- always points to the most recent staging build
+- `:edge` -- always points to the most recent staging build
 - `:staging-{run_number}` -- immutable tag for traceability
+
+`:latest` is reserved for stable releases pushed by the `docker.yml` workflow on `v*` tags.


### PR DESCRIPTION
## Summary

- Change staging builds to push `:edge` tag instead of `:latest`
- Update `docker-compose.staging.yml` to pull `:edge` images
- Reserve `:latest` for stable releases pushed by the `docker.yml` workflow on `v*` tags

This prevents staging deploys from overwriting release images that forum admins depend on.

## Test plan

- [ ] Verify staging deploy pushes `:edge` and `:staging-N` tags to GHCR
- [ ] Verify production compose still references `${BARAZO_API_VERSION:-latest}` (unchanged)