### PR TITLE
fix(ci): copy .npmrc during workspace sync for pnpm deploy

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -82,6 +82,7 @@ jobs:
           cp _workspace/package.json .
           cp _workspace/pnpm-lock.yaml .
           cp _workspace/pnpm-workspace.yaml .
+          cp _workspace/.npmrc .
           rm -rf _workspace
 
       - name: Checkout barazo-lexicons


### PR DESCRIPTION
## Summary
- Adds `cp _workspace/.npmrc .` to the workspace sync step in deploy-staging.yml
- Ensures the `inject-workspace-packages=true` setting is available during Docker builds

## Context
pnpm v10 requires `inject-workspace-packages=true` in `.npmrc` for `pnpm deploy` to work with workspace dependencies. The deploy workflow copies workspace root files but was missing `.npmrc`.

**Coordinated with:** barazo-forum/barazo-workspace (adds the setting) and barazo-forum/barazo-api (Dockerfile update).

## Test plan
- [ ] Merge barazo-workspace PR first
- [ ] Verify deploy-staging workflow copies .npmrc correctly
- [ ] Verify Docker build succeeds after all 3 PRs are merged