### PR TITLE
fix(ci): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build-smoke-test.yml
+++ b/.github/workflows/build-smoke-test.yml
@@ -36,10 +36,10 @@ jobs:
       BARAZO_WEB_VERSION: latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA' || github.event_name == 'pull_request_target')
-        uses: contributor-assistant/github-action@v2.6.1
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_BOT_TOKEN }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -67,10 +67,10 @@ jobs:
       # Checkout all repos (public -- no PAT needed)
       # ----------------------------------------------------------------------
       - name: Checkout barazo-deploy
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Checkout barazo-workspace
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: barazo-forum/barazo-workspace
           path: _workspace
@@ -86,20 +86,20 @@ jobs:
           rm -rf _workspace
 
       - name: Checkout barazo-lexicons
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: barazo-forum/barazo-lexicons
           path: barazo-lexicons
 
       - name: Checkout barazo-api
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: barazo-forum/barazo-api
           ref: ${{ steps.refs.outputs.api_ref }}
           path: barazo-api
 
       - name: Checkout barazo-web
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: barazo-forum/barazo-web
           ref: ${{ steps.refs.outputs.web_ref }}

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -17,10 +17,10 @@ jobs:
     name: Scan IaC & Config
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Trivy config scan
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@c1824fd6edce30d7ab345a9989de00bbd46ef284 # 0.34.0
         with:
           scan-type: 'config'
           scan-ref: '.'
@@ -29,7 +29,7 @@ jobs:
           output: 'trivy-config.sarif'
 
       - name: Upload to GitHub Security
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@f5c2471be782132e47a6e6f9c725e56730d6e9a3 # v3
         if: always()
         with:
           sarif_file: 'trivy-config.sarif'

--- a/.github/workflows/validate-compose.yml
+++ b/.github/workflows/validate-compose.yml
@@ -14,7 +14,7 @@ jobs:
     name: Validate Docker Compose
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Validate dev compose
         run: docker compose -f docker-compose.dev.yml config --quiet


### PR DESCRIPTION
## Summary
- Pin all third-party actions to commit SHAs across build-smoke-test.yml, cla.yml, trivy-scan.yml, validate-compose.yml, deploy-staging.yml
- Replace `aquasecurity/trivy-action@master` with pinned release `0.34.0`
- Resolves all actions/unpinned-tag code scanning alerts

## Test plan
- [ ] CI passes (validate-compose, build-smoke-test)