### PR TITLE
fix(tap): add vote collection to firehose filters

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -46,7 +46,7 @@ services:
     environment:
       TAP_RELAY_URL: ${TAP_RELAY_URL:-https://bsky.network}
       TAP_SIGNAL_COLLECTION: forum.barazo.topic.post
-      TAP_COLLECTION_FILTERS: forum.barazo.topic.post,forum.barazo.topic.reply,forum.barazo.interaction.reaction
+      TAP_COLLECTION_FILTERS: forum.barazo.topic.post,forum.barazo.topic.reply,forum.barazo.interaction.reaction,forum.barazo.interaction.vote
       TAP_DATABASE_URL: sqlite:///data/tap.db
       TAP_ADMIN_PASSWORD: ${TAP_ADMIN_PASSWORD:-tap_dev_secret}
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
     environment:
       TAP_RELAY_URL: ${RELAY_URL:-https://bsky.network}
       TAP_SIGNAL_COLLECTION: forum.barazo.topic.post
-      TAP_COLLECTION_FILTERS: forum.barazo.topic.post,forum.barazo.topic.reply,forum.barazo.interaction.reaction
+      TAP_COLLECTION_FILTERS: forum.barazo.topic.post,forum.barazo.topic.reply,forum.barazo.interaction.reaction,forum.barazo.interaction.vote
       TAP_DATABASE_URL: sqlite:///data/tap.db
       TAP_ADMIN_PASSWORD: ${TAP_ADMIN_PASSWORD}
     volumes:


### PR DESCRIPTION
## Summary
- Add `forum.barazo.interaction.vote` to `TAP_COLLECTION_FILTERS` in `docker-compose.yml` (production) and `docker-compose.dev.yml` (development)
- Without this, the TAP relay ignores vote records from the firehose, preventing the vote system (Issue barazo-forum/barazo-workspace#18) from functioning

## Test plan
- [ ] CI checks pass
- [ ] After deploying, verify TAP relay subscribes to vote collection events