### PR TITLE
chore: remove broken dev:seed script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "dev:infra": "docker compose -f barazo-deploy/docker-compose.dev.yml up -d",
     "dev:infra:down": "docker compose -f barazo-deploy/docker-compose.dev.yml down",
     "dev:infra:logs": "docker compose -f barazo-deploy/docker-compose.dev.yml logs -f",
-    "dev:seed": "pnpm tsx seed/seed.ts",
     "dev:api": "pnpm --filter barazo-api dev",
     "dev:web": "pnpm --filter barazo-web dev",
     "test": "pnpm -r test",


### PR DESCRIPTION
## Summary
- Removes `dev:seed` script from workspace package.json -- it references `seed/seed.ts` which does not exist
- Identified during pre-P3 review (Issue 29)

## Test plan
- [ ] `pnpm install` still works
- [ ] Other dev scripts (`dev:infra`, `dev:api`, `dev:web`) unaffected