### PR TITLE
fix(caddy): route OAuth metadata endpoints to API

### DIFF
--- a/.env.staging
+++ b/.env.staging
@@ -38,7 +38,7 @@ VALKEY_PASSWORD="CHANGE_ME"
 
 TAP_ADMIN_PASSWORD="CHANGE_ME"
 RELAY_URL="wss://bsky.network"
-OAUTH_CLIENT_ID="https://staging.barazo.forum"
+OAUTH_CLIENT_ID="https://staging.barazo.forum/oauth-client-metadata.json"
 OAUTH_REDIRECT_URI="https://staging.barazo.forum/api/auth/callback"
 
 # ==============================================================================

--- a/Caddyfile
+++ b/Caddyfile
@@ -24,6 +24,14 @@
 		}
 	}
 
+	# OAuth metadata (AT Protocol requires PDS to fetch these from the client_id origin)
+	handle /oauth-client-metadata.json {
+		reverse_proxy barazo-api:3000
+	}
+	handle /jwks.json {
+		reverse_proxy barazo-api:3000
+	}
+
 	# API routes -> barazo-api:3000
 	handle /api/* {
 		reverse_proxy barazo-api:3000


### PR DESCRIPTION
## Summary

- Add Caddy routes for `/oauth-client-metadata.json` and `/jwks.json` to forward them to `barazo-api:3000`
- Fix `OAUTH_CLIENT_ID` in `.env.staging` to point to the actual metadata URL

The AT Protocol OAuth flow requires the PDS to fetch client metadata from the `client_id` URL. These endpoints were served by the API at the root level (not under `/api/*`), so Caddy forwarded them to Next.js, which returned 404. This broke the entire login flow.

## Test plan

- [ ] Verify `curl https://staging.barazo.forum/oauth-client-metadata.json` returns JSON (not 404)
- [ ] Verify `curl https://staging.barazo.forum/jwks.json` returns JSON
- [ ] Test login flow with a Bluesky handle on staging