### PR TITLE
fix(deploy): add retry loop to login endpoint verification

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -304,17 +304,22 @@ jobs:
             cd ${{ env.DEPLOY_PATH }}
             echo "Verifying login endpoint returns valid redirect URL..."
 
-            # Test via internal Docker network (same as browser -> Caddy -> API)
-            RESPONSE=$(docker compose ${{ env.COMPOSE_FILES }} exec -T barazo-api \
-              wget -qO- "http://localhost:3000/api/auth/login?handle=test.bsky.social" 2>&1 || true)
+            # Retry up to 6 times (30s total) -- API may still be starting after deploy
+            for i in $(seq 1 6); do
+              RESPONSE=$(docker compose ${{ env.COMPOSE_FILES }} exec -T barazo-api \
+                wget -qO- "http://localhost:3000/api/auth/login?handle=test.bsky.social" 2>&1 || true)
 
-            if echo "$RESPONSE" | grep -q '"url"'; then
-              echo "Login endpoint OK: response contains redirect URL"
-            else
-              echo "::warning::Login endpoint did not return expected {url} field"
-              echo "Response: $RESPONSE"
-              echo "This may indicate an OAuth configuration issue"
-            fi
+              if echo "$RESPONSE" | grep -q '"url"'; then
+                echo "Login endpoint OK: response contains redirect URL (attempt $i/6)"
+                exit 0
+              fi
+              echo "Login check attempt $i/6 failed, retrying in 5s..."
+              sleep 5
+            done
+
+            echo "::warning::Login endpoint did not return expected {url} field after 6 attempts"
+            echo "Response: $RESPONSE"
+            echo "This may indicate an OAuth configuration issue"
 
       # ----------------------------------------------------------------------
       # Rollback on failure


### PR DESCRIPTION
## Summary

- Adds a retry loop (6 attempts, 5s apart = 30s max) to the post-deploy login endpoint check
- Fixes the false warning seen in deploy run #22459035710 where `wget` got "connection refused" because the API was still starting

## Test plan

- [ ] Trigger a manual deploy and verify the login check passes on first or second attempt