### PR TITLE
fix(deploy): replace script_stop with set -e and fix login check

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -156,8 +156,8 @@ jobs:
           host: staging.barazo.forum
           username: deploy
           key: ${{ secrets.STAGING_SSH_KEY }}
-          script_stop: true
           script: |
+            set -e
             cd ${{ env.DEPLOY_PATH }}
             echo "Syncing configuration files from repo (commit ${{ github.sha }})..."
             BASE="https://raw.githubusercontent.com/barazo-forum/barazo-deploy/${{ github.sha }}"
@@ -211,8 +211,8 @@ jobs:
           host: staging.barazo.forum
           username: deploy
           key: ${{ secrets.STAGING_SSH_KEY }}
-          script_stop: true
           script: |
+            set -e
             cd ${{ env.DEPLOY_PATH }}
 
             echo "Pulling latest images..."
@@ -317,15 +317,16 @@ jobs:
           host: staging.barazo.forum
           username: deploy
           key: ${{ secrets.STAGING_SSH_KEY }}
-          script_stop: true
           script: |
+            set -e
             cd ${{ env.DEPLOY_PATH }}
             echo "Verifying login endpoint returns valid redirect URL..."
 
             # Retry up to 6 times (30s total) -- API may still be starting after deploy
+            # Use 127.0.0.1 (not localhost) -- Alpine may not resolve localhost to IPv4
             for i in $(seq 1 6); do
               RESPONSE=$(docker compose ${{ env.COMPOSE_FILES }} exec -T barazo-api \
-                wget -qO- "http://localhost:3000/api/auth/login?handle=test.bsky.social" 2>&1 || true)
+                wget -qO- "http://127.0.0.1:3000/api/auth/login?handle=test.bsky.social" 2>&1 || true)
 
               if echo "$RESPONSE" | grep -q '"url"'; then
                 echo "Login endpoint OK: response contains redirect URL (attempt $i/6)"


### PR DESCRIPTION
## Summary

- Remove `script_stop: true` from all `appleboy/ssh-action` steps -- this parameter was removed from the action in Dec 2024 and is silently ignored, meaning deploy scripts don't actually abort on errors
- Replace with shell-native `set -e` at the top of scripts that must abort on first error (config sync, image pull/deploy, login verification)
- Fix login verification to use `127.0.0.1` instead of `localhost` -- Alpine-based containers may not resolve `localhost` to IPv4, causing "Connection refused" even when the API is healthy

Fixes the "Unexpected input 'script_stop'" warnings visible in every deploy run.

## Test plan

- [ ] Deploy runs without "Unexpected input 'script_stop'" warnings
- [ ] Config sync step aborts if wget fails (set -e)
- [ ] Pull/deploy step aborts if docker compose pull fails
- [ ] Login verification successfully reaches the API endpoint