### PR TITLE
docs: replace migration references with drizzle-kit push for alpha

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,8 +37,8 @@ POSTGRES_DB="barazo"
 # Uses the application role with INSERT/UPDATE/DELETE/SELECT privileges
 DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}"
 
-# Migration database URL (used only by migration scripts)
-# Uses a migration role with DDL privileges
+# Migration database URL (reserved for beta -- not used in alpha)
+# Will use a migration role with DDL privileges when proper migrations are needed
 # MIGRATION_DATABASE_URL="postgresql://barazo_migrator:CHANGE_ME@postgres:5432/${POSTGRES_DB}"
 
 # ==============================================================================

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,7 +34,7 @@ Closes #<!-- issue number -->
 - [ ] No TypeScript errors (`pnpm typecheck`)
 - [ ] No ESLint warnings (`pnpm lint`)
 - [ ] Documentation updated (if applicable)
-- [ ] Database migration included (if schema changed)
+- [ ] Database schema updated (if schema changed)
 - [ ] Breaking changes documented below (if applicable)
 - [ ] CI checks pass
 - [ ] No secrets or credentials in code

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,7 @@ All Barazo environment variables with descriptions, defaults, and examples.
 | `POSTGRES_DB` | Yes | -- | Database name |
 | `POSTGRES_PORT` | No | `5432` | Host port mapping (dev compose only) |
 | `DATABASE_URL` | Yes | -- | Connection string for the API. Format: `postgresql://user:pass@postgres:5432/dbname` |
-| `MIGRATION_DATABASE_URL` | No | -- | Connection string for migrations (DDL role, if using role separation) |
+| `MIGRATION_DATABASE_URL` | No | -- | Connection string for schema changes (DDL role, if using role separation). Reserved for beta -- not used in alpha. |
 
 ## Cache (Valkey)
 

--- a/docs/deployment-checklist.md
+++ b/docs/deployment-checklist.md
@@ -88,7 +88,7 @@ This checklist covers the first production deployment of `barazo.forum`. For sel
   | `POSTGRES_PASSWORD` | (generated above) |
   | `VALKEY_PASSWORD` | (generated above) |
   | `DATABASE_URL` | `postgresql://barazo_app:<POSTGRES_PASSWORD>@postgres:5432/barazo` |
-  | `MIGRATION_DATABASE_URL` | `postgresql://barazo_migrator:<POSTGRES_PASSWORD>@postgres:5432/barazo` |
+  | ~~`MIGRATION_DATABASE_URL`~~ | Not used in alpha. Reserved for beta when migrations are needed. |
   | `TAP_ADMIN_PASSWORD` | (generated above) |
   | `SESSION_SECRET` | (generated above) |
   | `OAUTH_CLIENT_ID` | `https://barazo.forum` |
@@ -234,7 +234,7 @@ docker compose pull
 docker compose up -d
 ```
 
-Database migrations run automatically on API startup. If a migration introduced a breaking change, restore from backup (see [Backup & Restore](backups.md)).
+During alpha, the database schema is rebuilt on deploy. If a schema change causes issues, restore from backup (see [Backup & Restore](backups.md)).
 
 ### Daily Checks
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -171,7 +171,7 @@ To wipe all staging data and start fresh:
 ./scripts/reset-staging.sh
 ```
 
-This drops and recreates the database, flushes the cache, and restarts all services. The API applies migrations automatically on startup. Run `seed-staging.sh` afterward to repopulate test data.
+This drops and recreates the database, flushes the cache, and restarts all services. The schema is applied automatically on startup. Run `seed-staging.sh` afterward to repopulate test data.
 
 ### Smoke Test
 

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -213,11 +213,11 @@ Barazo uses three PostgreSQL roles with least-privilege access:
 
 | Role | Privileges | Used By |
 |------|-----------|---------|
-| `barazo_migrator` | DDL (CREATE, ALTER, DROP) | Migration scripts only |
+| `barazo_migrator` | DDL (CREATE, ALTER, DROP) | Schema changes (reserved for beta) |
 | `barazo_app` | DML (SELECT, INSERT, UPDATE, DELETE) | API server |
 | `barazo_readonly` | SELECT only | Search, public endpoints, reporting |
 
-The API server connects with `barazo_app` -- it cannot modify the schema. Migrations use `barazo_migrator` and run only during startup.
+The API server connects with `barazo_app` -- it cannot modify the schema. During alpha, schema is applied via `drizzle-kit push` at deploy time. In beta, `barazo_migrator` will run proper migrations.
 
 ### Connection Security
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -18,7 +18,7 @@ docker compose ps
 ./scripts/smoke-test.sh https://your-domain.com
 ```
 
-Database migrations run automatically when the API starts. No manual migration step is needed.
+The database schema is applied via `drizzle-kit push` during deployment. No manual schema step is needed.
 
 ## Pinned Version Upgrade
 
@@ -75,5 +75,5 @@ Major version bumps (e.g., 1.x to 2.x) may include breaking changes that require
 
 Common breaking changes to watch for:
 - **Environment variable renames** -- update your `.env` file
-- **Database schema changes** -- migrations run automatically, but rollback may require the backup
+- **Database schema changes** -- schema is pushed on deploy, but rollback may require the backup
 - **Caddy configuration changes** -- check if Caddyfile needs updates

--- a/scripts/reset-staging.sh
+++ b/scripts/reset-staging.sh
@@ -11,7 +11,7 @@
 # What it does:
 #   1. Stops API and Web services (keeps postgres/valkey running)
 #   2. Drops and recreates the staging database
-#   3. Restarts all services (API runs migrations on startup)
+#   3. Restarts all services (schema is applied on startup)
 #
 # Environment:
 #   COMPOSE_FILE  Docker Compose files (default: docker-compose.yml -f docker-compose.staging.yml)
@@ -95,7 +95,7 @@ echo "Flushing Valkey cache..."
 # On staging, we restart valkey instead to clear all data.
 $COMPOSE_CMD restart valkey
 
-# Step 4: Restart all services (API runs migrations on startup)
+# Step 4: Restart all services (schema is applied on startup)
 echo "Starting all services..."
 $COMPOSE_CMD up -d
 
@@ -112,6 +112,6 @@ fi
 
 echo ""
 echo "Staging reset complete."
-echo "The API will run database migrations automatically on startup."
+echo "The database schema will be applied automatically on startup."
 echo ""
 echo "To seed test data, run: ./scripts/seed-staging.sh"


### PR DESCRIPTION
## Summary
- Update docs, `.env.example`, PR template, and `reset-staging.sh` to reflect that alpha uses `drizzle-kit push` instead of migrations
- `MIGRATION_DATABASE_URL` marked as reserved for beta
- `barazo_migrator` role description updated to "reserved for beta"

## Test plan
- [ ] Verify no functional changes -- all edits are comments/docs only
- [ ] Confirm `.env.example` still works for fresh installs