### PR TITLE
docs: use gender-neutral example names

### DIFF
--- a/docs/pds-self-hosting.md
+++ b/docs/pds-self-hosting.md
@@ -20,7 +20,7 @@ Self-hosting a PDS makes sense in specific scenarios:
 |----------|--------------|
 | **Data sovereignty** | Keep all user data on infrastructure you control |
 | **Air-gapped environments** | Network-restricted deployments that cannot reach `bsky.social` |
-| **Organizational accounts** | Issue AT Protocol identities under your own domain (e.g., `@alice.yourorg.com`) |
+| **Organizational accounts** | Issue AT Protocol identities under your own domain (e.g., `@jay.yourorg.com`) |
 | **Regulatory compliance** | Data residency requirements that prohibit US-hosted PDS providers |
 
 If none of these apply, use the default setup. Users sign up via Bluesky's PDS and it works.
@@ -77,7 +77,7 @@ For detailed instructions, follow the official guide linked above. Do not rely o
 
 **No Barazo-specific configuration is needed.** AT Protocol OAuth handles PDS discovery automatically:
 
-1. A user enters their handle (e.g., `@alice.yourorg.com`)
+1. A user enters their handle (e.g., `@jay.yourorg.com`)
 2. Barazo resolves the handle to a DID
 3. The DID document points to the user's PDS
 4. OAuth proceeds with that PDS


### PR DESCRIPTION
## Summary

- Replace gendered placeholder name (`alice`) with gender-neutral alternative (`jay`) in PDS self-hosting documentation
- Aligns with project language standards

## Changes

- `docs/pds-self-hosting.md`: Two occurrences of `@alice.yourorg.com` replaced with `@jay.yourorg.com` (lines 23 and 80)
- Full repo searched (case-insensitive) to confirm no other occurrences

## Test plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Confirm no remaining occurrences of "alice" in the repo