### PR TITLE
fix(staging): use correct rate limit env var names

### DIFF
--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -21,9 +21,11 @@ services:
     environment:
       NODE_ENV: staging
       LOG_LEVEL: debug
-      # Relaxed rate limits for testing
-      RATE_LIMIT_WINDOW_MS: "60000"
-      RATE_LIMIT_MAX_REQUESTS: "1000"
+      # Relaxed rate limits for testing (must match env vars in barazo-api env.ts)
+      RATE_LIMIT_READ_ANON: "1000"
+      RATE_LIMIT_READ_AUTH: "1000"
+      RATE_LIMIT_WRITE: "100"
+      RATE_LIMIT_AUTH: "100"
 
   # Override Web for staging
   barazo-web:


### PR DESCRIPTION
## Summary

- Staging compose was setting `RATE_LIMIT_WINDOW_MS` and `RATE_LIMIT_MAX_REQUESTS`, but the API reads `RATE_LIMIT_READ_ANON`, `RATE_LIMIT_READ_AUTH`, `RATE_LIMIT_WRITE`, and `RATE_LIMIT_AUTH`
- The mismatch left the default 100 req/min for anonymous reads, causing SSR requests from barazo-web to get 429'd under normal traffic
- This is the root cause of the "Unable to connect to the forum API" error on staging.barazo.forum

Fixes barazo-forum/barazo-workspace#146

## Test plan

- [ ] After merge, verify staging deploys successfully
- [ ] Load staging.barazo.forum and confirm no API error
- [ ] Confirm API logs no longer show 429 responses to internal SSR requests