### PR TITLE
fix(deploy): prune unused Docker images after deploy and add log rotation

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -221,6 +221,9 @@ jobs:
             echo "Starting containers..."
             docker compose ${{ env.COMPOSE_FILES }} up -d
 
+            echo "Pruning unused images..."
+            docker image prune -f
+
             echo "Deploy complete at $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 
       # ----------------------------------------------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,12 @@
 #
 # Startup order: postgres -> valkey -> tap -> barazo-api -> barazo-web -> caddy
 
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "3"
+
 services:
   # ---------------------------------------------------------------------------
   # PostgreSQL 16 with pgvector (full-text + optional semantic search)
@@ -17,6 +23,7 @@ services:
   postgres:
     image: pgvector/pgvector:pg16
     restart: unless-stopped
+    logging: *default-logging
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -40,6 +47,7 @@ services:
   valkey:
     image: valkey/valkey:9-alpine
     restart: unless-stopped
+    logging: *default-logging
     command: >
       valkey-server
       --requirepass ${VALKEY_PASSWORD}
@@ -68,6 +76,7 @@ services:
     image: ghcr.io/bluesky-social/indigo/tap:latest
     platform: linux/amd64
     restart: unless-stopped
+    logging: *default-logging
     environment:
       TAP_RELAY_URL: ${RELAY_URL:-https://bsky.network}
       TAP_SIGNAL_COLLECTION: forum.barazo.topic.post
@@ -88,6 +97,7 @@ services:
   barazo-api:
     image: ghcr.io/barazo-forum/barazo-api:${BARAZO_API_VERSION:-latest}
     restart: unless-stopped
+    logging: *default-logging
     environment:
       NODE_ENV: production
       DATABASE_URL: ${DATABASE_URL}
@@ -137,6 +147,7 @@ services:
   barazo-web:
     image: ghcr.io/barazo-forum/barazo-web:${BARAZO_WEB_VERSION:-latest}
     restart: unless-stopped
+    logging: *default-logging
     environment:
       NODE_ENV: production
       API_INTERNAL_URL: http://barazo-api:3000
@@ -162,6 +173,7 @@ services:
   caddy:
     image: caddy:2-alpine
     restart: unless-stopped
+    logging: *default-logging
     environment:
       COMMUNITY_DOMAIN: ${COMMUNITY_DOMAIN}
     ports:


### PR DESCRIPTION
## Summary
- Add `docker image prune -f` after `docker compose up -d` in the staging deploy workflow to remove dangling images from previous deploys
- Add json-file log rotation (`10m` x 3 files) to all services via shared `x-logging` YAML anchor

Fixes barazo-forum/barazo-workspace#70

## Context
The staging VPS (38GB disk) filled up with 146 Docker images (29GB) because the deploy workflow never cleaned up old image layers. Each deploy pulls ~800MB of new images while the old ones remain as dangling references.

Additionally, Docker's default json-file log driver has no size limit, so container logs can grow unbounded on long-running instances.

## Changes
- `.github/workflows/deploy-staging.yml` — add `docker image prune -f` after successful container start
- `docker-compose.yml` — add `x-logging` anchor with `max-size: 10m` / `max-file: 3`, applied to all 6 services

## Test plan
- [x] `docker compose config --quiet` validates successfully
- [ ] CI passes (Compose validation, Trivy scan)
- [ ] Next staging deploy prunes images automatically