### PR TITLE
fix(deploy): add barazo-plugins checkout for plugin-signatures dependency

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -91,6 +91,12 @@ jobs:
           repository: singi-labs/barazo-lexicons
           path: barazo-lexicons
 
+      - name: Checkout barazo-plugins
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: singi-labs/barazo-plugins
+          path: barazo-plugins
+
       - name: Checkout barazo-api
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
## Summary

- Add checkout step for `barazo-plugins` repo in the staging deploy workflow
- Required because `barazo-api` depends on `@barazo/plugin-signatures` via a workspace `link:` reference
- Placed after `barazo-lexicons` and before `barazo-api` checkout (order matters for dependency resolution)

## Test plan

- [ ] Trigger a staging deploy and verify `pnpm install` resolves `@barazo/plugin-signatures` successfully
- [ ] Verify API image builds without `ERR_MODULE_NOT_FOUND` for plugin-signatures