### PR TITLE
fix(caddy): add docs.barazo.forum site block

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -12,6 +12,18 @@
 	admin off
 }
 
+# ---------------------------------------------------------------------------
+# Documentation site (static export served from /var/www/docs.barazo.forum/)
+# ---------------------------------------------------------------------------
+docs.barazo.forum {
+	header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
+
+	root * /var/www/docs.barazo.forum
+	file_server
+
+	try_files {path} {path}index.html /404.html
+}
+
 {$COMMUNITY_DOMAIN} {
 	# HSTS -- enforce HTTPS for all future requests (2 years, preload-eligible)
 	header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,6 +187,7 @@ services:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddydata:/data
       - caddyconfig:/config
+      - /var/www/docs.barazo.forum:/var/www/docs.barazo.forum:ro
     networks:
       - frontend
     depends_on:


### PR DESCRIPTION
## Summary

- Add `docs.barazo.forum` Caddy site block to serve the static docs export
- Bind-mount `/var/www/docs.barazo.forum` into the Caddy container (read-only)
- The deploy workflow in barazo-docs already rsyncs the built site to this path, but Caddy was never configured to serve it -- causing TLS handshake failures

## Post-merge steps

After merging, SSH into the VPS and run:
```bash
cd /opt/barazo
git pull
docker compose up -d caddy
```

Caddy will auto-obtain a Let's Encrypt certificate for `docs.barazo.forum` on first request.

## Test plan

- [ ] Verify `curl -sI https://docs.barazo.forum/` returns 200 after deploy
- [ ] Verify HSTS header is present
- [ ] Verify 404 page works for non-existent paths