### PR TITLE
fix(docs): update monitoring domain to monitoring.singi.dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -145,7 +145,7 @@ LOG_LEVEL="info"
 # from singi-labs/monitoring. This variable tells Caddy which domain to proxy.
 
 # Domain for the Grafana dashboard (needs a DNS A record pointing to this VPS)
-# GRAFANA_DOMAIN="monitor.barazo.forum"
+# GRAFANA_DOMAIN="monitoring.singi.dev"
 
 # ==============================================================================
 # Backups (Production only)

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -45,7 +45,7 @@ docker stats --no-stream
 
 ### Grafana Dashboard
 
-The monitoring stack (Prometheus + Grafana) provides real-time dashboards and alerting for all Singi Labs VPSes. Access it at `https://monitor.barazo.forum`.
+The monitoring stack (Prometheus + Grafana) provides real-time dashboards and alerting for all Singi Labs VPSes. Access it at `https://monitoring.singi.dev`.
 
 Available dashboards:
 - **Singi Labs -- VPS Overview**: All VPSes at a glance (CPU, RAM, disk, network, container metrics)

--- a/infrastructure/staging.md
+++ b/infrastructure/staging.md
@@ -118,7 +118,7 @@ This VPS is the monitoring hub for all Singi Labs VPSes. It runs Prometheus, Gra
 | Component | Purpose |
 |-----------|---------|
 | Prometheus | Scrapes and stores metrics (30-day retention) |
-| Grafana | Dashboards and alerting at `monitor.barazo.forum` |
+| Grafana | Dashboards and alerting at `monitoring.singi.dev` |
 | node_exporter | Host CPU, RAM, disk, network metrics |
 | cAdvisor | Per-container resource metrics |
 | WireGuard | VPN tunnel to remote VPSes (10.10.0.0/24) |


### PR DESCRIPTION
## Summary
- Update Grafana domain references from `monitor.barazo.forum` to `monitoring.singi.dev` in .env.example, administration.md, and staging.md

Since the monitoring hub serves all Singi Labs infrastructure, the domain belongs under singi.dev.

## Test plan
- [ ] CI passes