### PR TITLE
docs: replace GitHub Discussions link with Bluesky in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Detailed guides are in the [`docs/`](docs/) directory:
 ## Community
 
 - **Website:** [barazo.forum](https://barazo.forum)
-- **Discussions:** [GitHub Discussions](https://github.com/orgs/singi-labs/discussions)
+- **Bluesky:** [@barazo.forum](https://bsky.app/profile/barazo.forum)
 - **Issues:** [Report bugs](https://github.com/singi-labs/barazo-deploy/issues)
 
 ---


### PR DESCRIPTION
## Summary

- We never enabled GitHub Discussions on the `singi-labs` org, so the link 404s for anyone who clicks it.
- Replaces the `Discussions` line in the Community section with a Bluesky link to the product handle (which is where people already reach out).
- Part of an org-wide sweep across all 14 repos (see also: companion PRs).

## Test plan

- [x] Visual review of rendered README
- [x] Verify Bluesky link resolves