### PR TITLE
feat(caddy): import custom *.caddy vhosts from ./caddy.d

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ Thumbs.db
 *.swp
 *.swo
 .worktrees/
+
+# Custom Caddy vhosts (machine-local, may contain private domains)
+caddy.d/*
+!caddy.d/.gitkeep

--- a/Caddyfile
+++ b/Caddyfile
@@ -71,3 +71,13 @@ docs.barazo.forum {
 	header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
 	reverse_proxy grafana:3050
 }
+
+# ---------------------------------------------------------------------------
+# Custom site blocks (optional)
+# ---------------------------------------------------------------------------
+# Drop additional *.caddy files into ./caddy.d/ to serve extra vhosts (e.g. a
+# status page, a comments backend, another app on the same box) without forking
+# this template. The directory is mounted read-only at /etc/caddy/conf.d and is
+# gitignored, so your custom config survives `git pull` and never ships here.
+# An empty directory is a no-op.
+import /etc/caddy/conf.d/*.caddy

--- a/README.md
+++ b/README.md
@@ -47,6 +47,24 @@ Everything you need to self-host a [Barazo](https://github.com/singi-labs) forum
 
 Production uses two-network segmentation: PostgreSQL and Valkey sit on the `backend` network only and are unreachable from Caddy or the frontend. Only ports 80 and 443 are exposed externally.
 
+### Custom Caddy vhosts
+
+Caddy imports any `*.caddy` file you drop into `./caddy.d/`, so you can serve extra
+sites on the same box (a status page, another app, a comments backend) without
+forking this template. The directory is mounted read-only at `/etc/caddy/conf.d`
+and its contents are gitignored, so your config survives `git pull` and is never
+committed here. Example `caddy.d/status.example.com.caddy`:
+
+```caddy
+status.example.com {
+	reverse_proxy my-status-app:8080
+}
+```
+
+Reverse-proxy targets must share Caddy's `frontend` network (attach your container
+to it as an external network). An empty `caddy.d/` directory is a no-op. After
+adding or changing a file, recreate Caddy: `docker compose up -d caddy`.
+
 ---
 
 ## Image Tags

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,6 +185,7 @@ services:
       - "443:443/udp"   # HTTP/3 (QUIC)
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./caddy.d:/etc/caddy/conf.d:ro      # optional custom *.caddy vhosts (gitignored)
       - caddydata:/data
       - caddyconfig:/config
       - /var/www/docs.barazo.forum:/var/www/docs.barazo.forum:ro


### PR DESCRIPTION
Closes #112

Adds a generic extension point so operators can serve extra vhosts on the same box without forking the template or editing the tracked `Caddyfile`.

## Changes
- `Caddyfile`: `import /etc/caddy/conf.d/*.caddy` at the end (empty glob = no-op, just a warn).
- `docker-compose.yml`: mount `./caddy.d:/etc/caddy/conf.d:ro` on the caddy service.
- `.gitignore`: ignore `caddy.d/*` except `.gitkeep` — custom config stays machine-local and survives `git pull`.
- `caddy.d/.gitkeep`, README section.

## Validation
`caddy validate` passes with `COMMUNITY_DOMAIN` set, both with an empty `caddy.d/` (template default) and with a real `*.caddy` file present.

Reverse-proxy targets must share Caddy's `frontend` network (attach as external).