### PR TITLE
fix(ci): set AI_ENCRYPTION_KEY in smoke-test env

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -177,6 +177,7 @@ jobs:
       DATABASE_URL: postgresql://barazo:ci_smoke_test@postgres:5432/barazo
       TAP_ADMIN_PASSWORD: ci_smoke_test
       SESSION_SECRET: ci_session_secret_not_real_extend_to_32
+      AI_ENCRYPTION_KEY: ci_ai_encryption_key_not_real_extend_to_32
       RELAY_URL: wss://bsky.network
       COMMUNITY_DID: did:plc:ci-smoke-test
       COMMUNITY_NAME: CI Smoke Test

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -65,7 +65,7 @@ if [ -z "$REMOTE_URL" ]; then
   fi
 
   # Check Valkey connection
-  if docker compose -f "$COMPOSE_FILE" exec -T valkey valkey-cli ping 2>/dev/null | grep -q "PONG"; then
+  if docker compose -f "$COMPOSE_FILE" exec -T valkey valkey-cli -a "${VALKEY_PASSWORD:-}" ping 2>/dev/null | grep -q "PONG"; then
     pass "Valkey is responding"
   else
     fail "Valkey is not responding"
@@ -79,8 +79,11 @@ if [ -n "$REMOTE_URL" ]; then
   BASE_URL="$REMOTE_URL"
   echo "Remote deployment checks ($BASE_URL):"
 else
-  BASE_URL="http://localhost:3000"
-  echo "HTTP checks (via localhost):"
+  # App ports are not published to the host -- only Caddy (port 80) is.
+  # Route local HTTP checks through Caddy, which proxies /api/* -> barazo-api
+  # and everything else -> barazo-web.
+  BASE_URL="http://localhost"
+  echo "HTTP checks (via Caddy on localhost):"
 fi
 
 # API health
@@ -109,7 +112,7 @@ echo "Frontend checks:"
 if [ -n "$REMOTE_URL" ]; then
   HOMEPAGE=$(curl -s "$BASE_URL" 2>/dev/null || echo "")
 else
-  HOMEPAGE=$(curl -s "http://localhost:3001" 2>/dev/null || echo "")
+  HOMEPAGE=$(curl -s "$BASE_URL" 2>/dev/null || echo "")
 fi
 
 if echo "$HOMEPAGE" | grep -qi "barazo\|html"; then


### PR DESCRIPTION
## Problem

The staging deploy is gated on the `smoke-test` job, which fails at **Start full stack** with:

```
dependency failed to start: container barazo-deploy-barazo-api-1 is unhealthy
```

The API container crash-loops on startup:

```
Error: Invalid environment configuration:
✖ Too small: expected string to have >=32 characters → at AI_ENCRYPTION_KEY
```

## Root cause

`barazo-api` validates `AI_ENCRYPTION_KEY: z.string().min(32)` (src/config/env.ts:51) — required, no default. The `smoke-test` job's `env:` block never set it, so compose passed `${AI_ENCRYPTION_KEY:-}` = empty string, which fails `min(32)`. The API never reaches healthy, and `docker compose up` aborts the gate.

## Fix

Add a dummy ≥32-char `AI_ENCRYPTION_KEY` to the smoke-test job env, matching the existing `SESSION_SECRET` pattern. CI-only fixture value.

## Verification

Triggering deploy-staging on this branch to confirm the smoke-test job goes green.