### PR TITLE
fix(deploy): pull public images anonymously on staging VPS

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -333,6 +333,10 @@ jobs:
             set -e
             cd ${{ env.DEPLOY_PATH }}
 
+            # Images are public on ghcr.io -- pull anonymously. Drop any stale
+            # registry credential so a leftover token can't cause "denied".
+            docker logout ghcr.io || true
+
             echo "Pulling latest images..."
             docker compose ${{ env.COMPOSE_FILES }} pull barazo-api barazo-web
 


### PR DESCRIPTION
## Problem

The staging deploy fails at **Pull new images and deploy**:

```
Image ghcr.io/singi-labs/barazo-api:edge  Error error from registry: denied
```

## Root cause

The `barazo-api`/`barazo-web` ghcr.io packages are now public (verified: anonymous manifest fetch returns HTTP 200). But the VPS `deploy` user's `~/.docker/config.json` holds a stale `ghcr.io` credential. Docker presents that token and the registry replies `denied` instead of falling back to anonymous access.

## Fix

Run `docker logout ghcr.io` before `docker compose pull`. The images are public, so anonymous pull succeeds and the deploy no longer depends on any stored credential. Idempotent and resilient to future stale tokens. The logout persists for the same job, so the rollback step's digest pulls are covered too.

## Verification

Will dispatch deploy-staging after merge and confirm it runs through to green.